### PR TITLE
コマンドの権限チェックにtestPermission()を使用する

### DIFF
--- a/src/space/yurisi/Command/LogCommand.php
+++ b/src/space/yurisi/Command/LogCommand.php
@@ -23,7 +23,7 @@ class LogCommand extends Command {
 
     public function execute(CommandSender $sender, string $label, array $args): bool {
         if (!$sender instanceof Player) return false;
-        if (!$sender->hasPermission(DefaultPermissions::ROOT_OPERATOR)) return false;
+        if (!$this->testPermission($sender)) return false;
         if (!isset($args[0])) {
             $msg = ["ON", "OFF"];
             $this->main->changeParam($sender);


### PR DESCRIPTION
これによって、権限が無いプレイヤーのコマンド予測にこのコマンドが出なくなり、実行した場合は権限が無い旨のメッセージが表示されます
